### PR TITLE
Add BenSampo/laravel-enum support (checkEnum / checkEnumNullable)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^8.0|^9.0|^10.0"
+        "bensampo/laravel-enum": "^6.10",
+        "illuminate/contracts": "^8.0|^9.0|^10.0",
+        "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev": {
         "nunomaduro/collision": "^5.10|^6.0|^7.0",

--- a/src/CheckConstraintsServiceProvider.php
+++ b/src/CheckConstraintsServiceProvider.php
@@ -2,11 +2,13 @@
 
 namespace Ditscheri\CheckConstraints;
 
+use BenSampo\Enum\Enum;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -32,6 +34,22 @@ class CheckConstraintsServiceProvider extends PackageServiceProvider
             return $this->addCommand('check', compact('expression', 'constraint'));
         });
 
+        Blueprint::macro('checkEnum', function(string $column, string $enumClass, ?string $constraint = null) {
+            /** @var Blueprint $this */
+            $constraint = $constraint ?: $this->createCheckName($column);
+            $expression = $this->createEnumExpression($column, $enumClass, false);
+
+            return $this->check($expression, $constraint);
+        });
+
+        Blueprint::macro('checkEnumNullable', function(string $column, string $enumClass, ?string $constraint = null) {
+            /** @var Blueprint $this */
+            $constraint = $constraint ?: $this->createCheckName($column);
+            $expression = $this->createEnumExpression($column, $enumClass, true);
+
+            return $this->check($expression, $constraint);
+        });
+
         Blueprint::macro('dropCheck', function (string|array $constraints) {
             /** @var Blueprint $this */
             $constraints = is_array($constraints) ? $constraints : func_get_args();
@@ -45,6 +63,36 @@ class CheckConstraintsServiceProvider extends PackageServiceProvider
                 ->replaceMatches('#[\W_]+#', '_')
                 ->trim('_')
                 ->lower();
+        });
+
+        Blueprint::macro('createEnumExpression', function (string $column, string $enumClass, bool $nullable = false) {
+            /** @var Blueprint $this */
+            /** @var class-string $enumClass */
+            if (!class_exists($enumClass) || !is_subclass_of($enumClass, Enum::class)) {
+                throw new InvalidArgumentException("$enumClass must be existing and subclass of " . Enum::class);
+            }
+
+            $values = collect($enumClass::getValues());
+            $expression = "{$column} IN ";
+            if(is_int($values->first())){
+                if($values->some(fn($value) => !is_int($value))){
+                    throw new InvalidArgumentException("All values in $enumClass must be same type (string or integer).");
+                }
+                $expression .= "(".implode(", ", $values->toArray()).")";
+            }else if(is_string($values->first())){
+                if($values->some(fn($value) => !is_string($value))){
+                    throw new InvalidArgumentException("All values in $enumClass must be same type (string or integer)");
+                }
+                $expression .= "('".implode("', '", $values->toArray())."')";
+            }else{
+                throw new InvalidArgumentException("Only string and integer values are supported");
+            }
+
+            if($nullable){
+                $expression = "{$column} IS NULL OR {$expression}";
+            }
+
+            return $expression;
         });
 
         Grammar::macro('compileCheck', function (Blueprint $blueprint, Fluent $command) {

--- a/tests/BlueprintTest.php
+++ b/tests/BlueprintTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use BenSampo\Enum\Enum;
 use Illuminate\Database\Schema\Blueprint;
 
 it('can generate default names', function () {
@@ -21,3 +22,86 @@ it('can use custom names', function () {
     $commands = $blueprint->getCommands();
     $this->assertSame('adults_only', $commands[0]->constraint);
 });
+
+final class StatusInt extends Enum {
+    const Draft = 1;
+    const Published = 2;
+    const Archived = 3;
+}
+
+it('can generate enum (consists with integer values) checks', function () {
+    $blueprint = new Blueprint('events');
+    $blueprint->checkEnum('status', StatusInt::class);
+    $commands = $blueprint->getCommands();
+    $this->assertSame('status IN (1, 2, 3)', $commands[0]->expression);
+});
+
+it('can generate nullable enum (consists with integer values) checks', function () {
+    $blueprint = new Blueprint('events');
+    $blueprint->checkEnumNullable('status', StatusInt::class);
+    $commands = $blueprint->getCommands();
+    $this->assertSame('status IS NULL OR status IN (1, 2, 3)', $commands[0]->expression);
+});
+
+final class StatusString extends Enum {
+    const Draft = 'draft';
+    const Published = 'published';
+    const Archived = 'archived';
+}
+
+it('can generate enum (consists with string values) checks', function () {
+    $blueprint = new Blueprint('events');
+    $blueprint->checkEnum('status', StatusString::class);
+    $commands = $blueprint->getCommands();
+    $this->assertSame("status IN ('draft', 'published', 'archived')", $commands[0]->expression);
+});
+
+it('can generate nullable enum (consists with string values) checks', function () {
+    $blueprint = new Blueprint('events');
+    $blueprint->checkEnumNullable('status', StatusString::class);
+    $commands = $blueprint->getCommands();
+    $this->assertSame("status IS NULL OR status IN ('draft', 'published', 'archived')", $commands[0]->expression);
+});
+
+final class StatusIntMixed extends Enum {
+    const Draft = 1;
+    const Published = 'published';
+    const Archived = 'archived';
+}
+
+it('throws exception for mixed type enum (int)', function () {
+    $blueprint = new Blueprint('events');
+    $blueprint->checkEnum('status', StatusIntMixed::class);
+})->throws(InvalidArgumentException::class);
+
+final class StatusStringMixed extends Enum {
+    const Draft = 'draft';
+    const Published = 1;
+    const Archived = 'archived';
+}
+
+it('throws exception for mixed type enum (string)', function () {
+    $blueprint = new Blueprint('events');
+    $blueprint->checkEnum('status', StatusStringMixed::class);
+})->throws(InvalidArgumentException::class);
+
+
+final class StatusFloat extends Enum {
+    const Draft = 1.0;
+    const Published = 2.0;
+    const Archived = 3.0;
+}
+it('throws exception for enum contains other than string or integer', function () {
+    $blueprint = new Blueprint('events');
+    $blueprint->checkEnum('status', StatusFloat::class);
+})->throws(InvalidArgumentException::class);
+
+it('throws exception for enum not exists', function () {
+    $blueprint = new Blueprint('events');
+    $blueprint->checkEnum('status', "hoobar");
+})->throws(InvalidArgumentException::class);
+
+it('throws exception for passing not subclass of Enum', function () {
+    $blueprint = new Blueprint('events');
+    $blueprint->checkEnum('status', InvalidArgumentException::class);
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
Hi, I added a support for BenSampo::Enum in this PR.

In my project currently working on using Enums for statuses / types of entities instead of using id/name table like admin_roles or admin_statues. 
My client request me to add a check constraint for the database column, I found your repository and decided to add enum support on your code. 

I would be happy if you could merge this. Please comment if there is anything.
thanks.